### PR TITLE
added target _blank to <a? tag

### DIFF
--- a/site/src/components/SiteDetails.svelte
+++ b/site/src/components/SiteDetails.svelte
@@ -23,7 +23,7 @@
 <main>
   <section style="flex: 2;">
     <h1 class="flex" style="gap: 1em; justify-content: space-between;">
-      <a href={url}>{title}</a>
+      <a href={url} target="_blank">{title}</a>
       {#if site.repo}
         <small class="flex" style="gap: 6pt;">
           <MarkGithub width="1.2em" /><a href={site.repo}>Repo</a>


### PR DESCRIPTION
When a user clicks on a link, it will open the link in a new tab instead of the same tab. This is necessary because on the links on the page link to an external site, it will be more reasonable to open those sites on separate tabs.


